### PR TITLE
[#123] Update to Psych 4.0.x

### DIFF
--- a/crystalball.gemspec
+++ b/crystalball.gemspec
@@ -41,11 +41,12 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'parser'
   spec.add_development_dependency 'pry'
   spec.add_development_dependency 'pry-byebug'
+  spec.add_development_dependency 'psych', '~> 4.0.0'
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency 'rubocop', ">= 0.56"
   spec.add_development_dependency 'rubocop-rspec'
   spec.add_development_dependency 'simplecov'
-  spec.add_development_dependency 'sqlite3', "~> 1.3.13"
+  spec.add_development_dependency 'sqlite3', "~> 1.4.2"
   spec.add_development_dependency 'yard'
 end

--- a/lib/crystalball/map_storage/yaml_storage.rb
+++ b/lib/crystalball/map_storage/yaml_storage.rb
@@ -33,7 +33,7 @@ module Crystalball
 
           paths.map do |file|
             metadata, *example_groups = file.read.split("---\n").reject(&:empty?).map do |yaml|
-              YAML.safe_load(yaml, [Symbol])
+              YAML.safe_load(yaml, permitted_classes: [Symbol])
             end
             example_groups = example_groups.inject(&:merge!)
 

--- a/lib/crystalball/rspec/runner.rb
+++ b/lib/crystalball/rspec/runner.rb
@@ -41,7 +41,7 @@ module Crystalball
           @config ||= begin
             config_src = if config_file
                            require 'yaml'
-                           YAML.safe_load(config_file.read)
+                           YAML.safe_load(config_file.read, permitted_classes: [Symbol])
                          else
                            {}
                          end

--- a/spec/rspec/runner_spec.rb
+++ b/spec/rspec/runner_spec.rb
@@ -24,7 +24,7 @@ describe Crystalball::RSpec::Runner do
     end
 
     context 'with CRYSTALBALL_CONFIG env variable set' do
-      let(:expected_config) { YAML.safe_load(Pathname('spec/fixtures/crystalball.yml').read) }
+      let(:expected_config) { YAML.safe_load(Pathname('spec/fixtures/crystalball.yml').read, permitted_classes: [Symbol]) }
 
       around do |example|
         ENV['CRYSTALBALL_CONFIG'] = 'spec/fixtures/crystalball.yml'


### PR DESCRIPTION
Psych.safe_load changed it's method signature and requires keyword args for 'permitted_classes'

Update the calls to Psych.safe_load and add it as an explicit gem dependency with a pessimistic lock on the version.


------------------

This is a patch to support recent Psych. Originally from https://github.com/toptal/crystalball/pull/134 