### PR TITLE
Uniq map file to remove metadata copies

### DIFF
--- a/lib/crystalball/map_storage/yaml_storage.rb
+++ b/lib/crystalball/map_storage/yaml_storage.rb
@@ -32,7 +32,7 @@ module Crystalball
           raise NoFilesFoundError, "No files or folder exists #{path}" unless paths.any?(&:exist?)
 
           paths.map do |file|
-            metadata, *example_groups = file.read.split("---\n").reject(&:empty?).map do |yaml|
+            metadata, *example_groups = file.read.split("---\n").reject(&:empty?).uniq.map do |yaml|
               YAML.safe_load(yaml, permitted_classes: [Symbol])
             end
             example_groups = example_groups.inject(&:merge!)


### PR DESCRIPTION
With parallel rspec, the map files look like:

```
 head -n 20 tmp/crystalball_data.yml
---
:type: Crystalball::ExecutionMap
:commit: bee5cbfe452f69b37a3cb212abd928df044a2c3a
:timestamp: 1678991682
:version:
---
:type: Crystalball::ExecutionMap
:commit: bee5cbfe452f69b37a3cb212abd928df044a2c3a
:timestamp: 1678991682
:version:
---
:type: Crystalball::ExecutionMap
:commit: bee5cbfe452f69b37a3cb212abd928df044a2c3a
:timestamp: 1678991682
:version:
---
"./spec/forms/password_reset_form_spec.rb[1:2:1]":
- app/models/budgeting.rb
- app/models/actualization/petty_cash.rb
- .....
```

The metadata can be injected multiple times, so there is a quickfix to remove duplicates from the manifest file on loading