### PR TITLE
Splat arguments to flat array

### DIFF
--- a/lib/crystalball/extensions/git/lib.rb
+++ b/lib/crystalball/extensions/git/lib.rb
@@ -12,7 +12,7 @@ module Git
 
       arg_opts = opts.map { |k, v| "--#{k}" if v }.compact + args
 
-      command('merge-base', arg_opts)
+      command('merge-base', *arg_opts)
     end
   end
 end


### PR DESCRIPTION
Newer version of ruby-git needs a flat array of arguments